### PR TITLE
fix: bootstrap with broker registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 - Add `daps.whitelisted.url` to `application.properties.`. Allows configuring whitelisted DAPS URLs already at configuration time.
 - Introduction of the setting `referred.check=true/false` in the application.properties. Enables or disables DAT claim referringConnector vs IDS message issuerConnector validation. Disabled by default.
 
+### Fixed
+- Fix bootstrapping with broker registration. The DSC now searches for the correct resource id when bootstrapping.
+
 ### Changed
 - Code base refactorings and removing of unused code.
 

--- a/src/main/java/io/dataspaceconnector/extension/bootstrap/Bootstrapper.java
+++ b/src/main/java/io/dataspaceconnector/extension/bootstrap/Bootstrapper.java
@@ -193,7 +193,7 @@ public class Bootstrapper {
     }
 
     /**
-     * Register resources at the broker.
+     * Register resources at the broker and link resource to broker.
      *
      * @param properties Bootstrap properties.
      * @param resources  The ids resources to register.
@@ -230,6 +230,7 @@ public class Bootstrapper {
                         }
                     }
 
+                    //send resource update message and update broker and resource link
                     var resourceResponse = brokerSvc
                             .sendResourceUpdateMessage(broker.toURI(), entry.getValue());
                     if (!brokerSvc.checkResponse(resourceResponse)) {

--- a/src/main/java/io/dataspaceconnector/service/resource/base/AbstractRelationService.java
+++ b/src/main/java/io/dataspaceconnector/service/resource/base/AbstractRelationService.java
@@ -152,8 +152,8 @@ public abstract class AbstractRelationService<K extends Entity, W extends Entity
      * @param entities The set of entities to be checked.
      * @throws ResourceNotFoundException if any of the entities is unknown.
      */
-    private void throwIfEntityDoesNotExist(final Set<UUID> entities) {
-        if (!doesExist(entities, x -> manyService.doesExist(x))) {
+    protected void throwIfEntityDoesNotExist(final Set<UUID> entities) {
+        if (!doesExist(entities, (x) -> manyService.doesExist(x))) {
             throw new ResourceNotFoundException("Could not find resource.");
         }
     }
@@ -165,7 +165,7 @@ public abstract class AbstractRelationService<K extends Entity, W extends Entity
      * @param doesElementExist The function that evaluates if an entity does exist.
      * @return true if all entities are known.
      */
-    private boolean doesExist(
+    protected boolean doesExist(
             final Set<UUID> entities, final Function<UUID, Boolean> doesElementExist) {
         for (final var entity : entities) {
             if (Boolean.FALSE.equals(doesElementExist.apply(entity))) {

--- a/src/main/java/io/dataspaceconnector/service/resource/relation/BrokerOfferedResourceLinker.java
+++ b/src/main/java/io/dataspaceconnector/service/resource/relation/BrokerOfferedResourceLinker.java
@@ -16,7 +16,6 @@
 package io.dataspaceconnector.service.resource.relation;
 
 import io.dataspaceconnector.common.exception.ErrorMessage;
-import io.dataspaceconnector.common.exception.ResourceNotFoundException;
 import io.dataspaceconnector.common.util.UUIDUtils;
 import io.dataspaceconnector.common.util.Utils;
 import io.dataspaceconnector.model.broker.Broker;
@@ -28,7 +27,10 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * Handles the relation between broker and offered resources.
@@ -44,7 +46,8 @@ public class BrokerOfferedResourceLinker extends OwningRelationService<Broker, O
     }
 
     /**
-     * This method also makes sure the bootstrap ids in entities are converted to the real DSC resource ids
+     * This method also makes sure the bootstrap ids in entities are
+     * converted to the real DSC resource ids.
      * {@inheritDoc}
      */
     @Override

--- a/src/main/java/io/dataspaceconnector/service/resource/relation/BrokerOfferedResourceLinker.java
+++ b/src/main/java/io/dataspaceconnector/service/resource/relation/BrokerOfferedResourceLinker.java
@@ -15,15 +15,20 @@
  */
 package io.dataspaceconnector.service.resource.relation;
 
+import io.dataspaceconnector.common.exception.ErrorMessage;
+import io.dataspaceconnector.common.exception.ResourceNotFoundException;
+import io.dataspaceconnector.common.util.UUIDUtils;
+import io.dataspaceconnector.common.util.Utils;
 import io.dataspaceconnector.model.broker.Broker;
 import io.dataspaceconnector.model.resource.OfferedResource;
 import io.dataspaceconnector.service.resource.base.OwningRelationService;
 import io.dataspaceconnector.service.resource.type.BrokerService;
 import io.dataspaceconnector.service.resource.type.OfferedResourceService;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.util.*;
 
 /**
  * Handles the relation between broker and offered resources.
@@ -36,5 +41,38 @@ public class BrokerOfferedResourceLinker extends OwningRelationService<Broker, O
     @Override
     protected final List<OfferedResource> getInternal(final Broker owner) {
         return owner.getOfferedResources();
+    }
+
+    /**
+     * This method also makes sure the bootstrap ids in entities are converted to the real DSC resource ids
+     * {@inheritDoc}
+     */
+    @Override
+    public void add(final UUID ownerId, final Set<UUID> entities) {
+        Utils.requireNonNull(ownerId, ErrorMessage.ENTITYID_NULL);
+        Utils.requireNonNull(entities, ErrorMessage.ENTITYSET_NULL);
+
+        if (entities.isEmpty()) {
+            // Prevent read call to database for the owner.
+            return;
+        }
+
+        Set<UUID> correctEntities = new HashSet<>(entities);
+
+        // Search if any id from the entities set is found in the bootstrapId field of a resource,
+        // if this is the case, replace it with the correct resource id
+        for (OfferedResource e : getManyService().getAll(Pageable.unpaged())) {
+            for (var entity : entities) {
+                if (e.getBootstrapId() != null) {
+                    UUID bootstrapId = UUIDUtils.uuidFromUri(e.getBootstrapId());
+                    if (bootstrapId.equals(entity)) {
+                        correctEntities.remove(bootstrapId);
+                        correctEntities.add(e.getId());
+                    }
+                }
+            }
+        }
+        throwIfEntityDoesNotExist(correctEntities);
+        addInternal(ownerId, correctEntities);
     }
 }


### PR DESCRIPTION
The DSC previously threw a resource not found exception when bootstrapping with broker registration. This was caused by the linker class searching for a resource with the wrong id (the bootstrap id, instead of the newly generated resource id). 

The fix implements the add method in the BrokerOfferedResourceLinker class. The method now searches for the resources and if it finds a resource with the given bootstrap id, it replaces it in the set with the correct resource id.