### PR TITLE
fix: make target queries unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Accessing the public self-description endpoint is now also possible for logged in admins.
 - The connector public key is now also persisted.
 - Set URI-converter and column-length for location in AppStore-entity. Tested AppStore-App deployment with Portainer 2.14.0
+- Query parameters are ignored if a query parameter with the same key is already defined in the target url
 
 ### Changed
 - Code base refactorings and removing of unused code.

--- a/src/main/java/io/dataspaceconnector/common/net/HttpService.java
+++ b/src/main/java/io/dataspaceconnector/common/net/HttpService.java
@@ -166,12 +166,11 @@ public class HttpService implements DataRetrievalService {
         Utils.requireNonNull(args, ErrorMessage.HTTP_ARGS_NULL);
 
         final var urlBuilder = createUrlBuilder(target);
-        HttpUrl targetUrl = toUrl(target);
-        var queryKeys = targetUrl.queryParameterNames();
+        final var targetUrl = toUrl(target);
+        final var queryKeys = targetUrl.queryParameterNames();
 
         if (args.getParams() != null) {
             for (final var key : args.getParams().keySet()) {
-                // makes sure the passed queries do not have the same key as queries in the target
                 if (!queryKeys.contains(key)) {
                     urlBuilder.addQueryParameter(key, args.getParams().get(key));
                 }

--- a/src/main/java/io/dataspaceconnector/common/net/HttpService.java
+++ b/src/main/java/io/dataspaceconnector/common/net/HttpService.java
@@ -31,6 +31,7 @@ import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayInputStream;
@@ -120,8 +121,7 @@ public class HttpService implements DataRetrievalService {
      */
     public Response post(final URL target, final HttpArgs args, final InputStream data)
             throws IOException {
-        Utils.requireNonNull(target, ErrorMessage.URI_NULL);
-        Utils.requireNonNull(args, ErrorMessage.HTTP_ARGS_NULL);
+        validateParameter(target, args);
 
         final var urlBuilder = createUrlBuilder(target);
 
@@ -143,8 +143,7 @@ public class HttpService implements DataRetrievalService {
         }
 
         final var response = httpSvc.send(requestBuilder.build());
-
-        final var output = new HttpResponse(response.code(), getBody(response));
+        final var output = getHttpResponse(response);
         response.close();
 
         return output;
@@ -162,8 +161,7 @@ public class HttpService implements DataRetrievalService {
      * @throws IllegalArgumentException if any of the parameters is null.
      */
     public Response get(final URL target, final HttpArgs args) throws IOException {
-        Utils.requireNonNull(target, ErrorMessage.URI_NULL);
-        Utils.requireNonNull(args, ErrorMessage.HTTP_ARGS_NULL);
+        validateParameter(target, args);
 
         final var urlBuilder = createUrlBuilder(target);
         final var targetUrl = toUrl(target);
@@ -195,10 +193,20 @@ public class HttpService implements DataRetrievalService {
             response = httpSvc.getWithHeaders(targetUri, headerCopy);
         }
 
-        final var output = new HttpResponse(response.code(), getBody(response));
+        final var output = getHttpResponse(response);
         response.close();
 
         return output;
+    }
+
+    @NotNull
+    private HttpResponse getHttpResponse(final okhttp3.Response response) throws IOException {
+        return new HttpResponse(response.code(), getBody(response));
+    }
+
+    private void validateParameter(final URL target, final HttpArgs args) {
+        Utils.requireNonNull(target, ErrorMessage.URI_NULL);
+        Utils.requireNonNull(args, ErrorMessage.HTTP_ARGS_NULL);
     }
 
     private InputStream getBody(final okhttp3.Response response) throws IOException {

--- a/src/main/java/io/dataspaceconnector/common/net/HttpService.java
+++ b/src/main/java/io/dataspaceconnector/common/net/HttpService.java
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ *  Contributors:
+ *       sovity GmbH
  */
 package io.dataspaceconnector.common.net;
 
@@ -34,7 +37,6 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * This class builds up http or httpS endpoint connections and sends GET requests.

--- a/src/main/java/io/dataspaceconnector/common/net/HttpService.java
+++ b/src/main/java/io/dataspaceconnector/common/net/HttpService.java
@@ -23,7 +23,10 @@ import io.dataspaceconnector.common.routing.dataretrieval.Response;
 import io.dataspaceconnector.common.exception.ErrorMessage;
 import io.dataspaceconnector.common.exception.NotImplemented;
 import io.dataspaceconnector.common.util.Utils;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.Request;
@@ -169,7 +172,7 @@ public class HttpService implements DataRetrievalService {
         if (args.getParams() != null) {
             for (final var key : args.getParams().keySet()) {
                 // makes sure the passed queries do not have the same key as queries in the target
-                if(!queryKeys.contains(key)) {
+                if (!queryKeys.contains(key)) {
                     urlBuilder.addQueryParameter(key, args.getParams().get(key));
                 }
             }

--- a/src/main/java/io/dataspaceconnector/common/net/HttpService.java
+++ b/src/main/java/io/dataspaceconnector/common/net/HttpService.java
@@ -20,10 +20,7 @@ import io.dataspaceconnector.common.routing.dataretrieval.Response;
 import io.dataspaceconnector.common.exception.ErrorMessage;
 import io.dataspaceconnector.common.exception.NotImplemented;
 import io.dataspaceconnector.common.util.Utils;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.Request;
@@ -37,6 +34,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class builds up http or httpS endpoint connections and sends GET requests.
@@ -148,7 +146,9 @@ public class HttpService implements DataRetrievalService {
     }
 
     /**
-     * Perform a get request.
+     * Perform a get request with query parameters (if given).
+     * If a query parameter is already found in the target URL it is ignored,
+     * so that the basis url of the target can not be bypassed.
      *
      * @param target The recipient of the request.
      * @param args   The request arguments.
@@ -161,10 +161,15 @@ public class HttpService implements DataRetrievalService {
         Utils.requireNonNull(args, ErrorMessage.HTTP_ARGS_NULL);
 
         final var urlBuilder = createUrlBuilder(target);
+        HttpUrl targetUrl = toUrl(target);
+        var queryKeys = targetUrl.queryParameterNames();
 
         if (args.getParams() != null) {
             for (final var key : args.getParams().keySet()) {
-                urlBuilder.addQueryParameter(key, args.getParams().get(key));
+                // makes sure the passed queries do not have the same key as queries in the target
+                if(!queryKeys.contains(key)) {
+                    urlBuilder.addQueryParameter(key, args.getParams().get(key));
+                }
             }
         }
 

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/ArtifactController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/ArtifactController.java
@@ -113,7 +113,8 @@ public class ArtifactController extends BaseResourceNotificationController<Artif
     /**
      * Returns data from the local database or a remote data source. In case of a remote data
      * source, all headers and query parameters included in this request will be used for the
-     * request to the backend. A query parameter is ignored if the same key is already defined in the target accessUrl.
+     * request to the backend.
+     * A query parameter is ignored if the same key is already defined in the target accessUrl.
      *
      * @param artifactId   Artifact id.
      * @param download     If the data should be forcefully downloaded.

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/ArtifactController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/ArtifactController.java
@@ -113,7 +113,7 @@ public class ArtifactController extends BaseResourceNotificationController<Artif
     /**
      * Returns data from the local database or a remote data source. In case of a remote data
      * source, all headers and query parameters included in this request will be used for the
-     * request to the backend.
+     * request to the backend. A query parameter is ignored if the same key is already defined in the target accessUrl.
      *
      * @param artifactId   Artifact id.
      * @param download     If the data should be forcefully downloaded.

--- a/src/test/java/io/dataspaceconnector/common/net/HttpServiceTest.java
+++ b/src/test/java/io/dataspaceconnector/common/net/HttpServiceTest.java
@@ -229,4 +229,40 @@ class HttpServiceTest {
         assertEquals(responseCode, result.getCode());
         assertArrayEquals(bytes, result.getData().readAllBytes());
     }
+
+    @Test
+    @SneakyThrows
+    void get_withAlreadyDefinedQuery() {
+        /* ARRANGE */
+        final var params = Map.of("name", "doe");
+        final var args = new HttpService.HttpArgs();
+        args.setParams(params);
+
+        final var target = new URL("https://target.com/?name=john");
+
+        final var response = new Response.Builder()
+                .request(new Request.Builder().url(target).build())
+                .protocol(Protocol.HTTP_1_1).code(200).message("Some message")
+                .body(ResponseBody.create("someBody", MediaType.parse("application/text")))
+                .build();
+
+        // The first response will be consumed by the first request, duplicate
+        final var response2 = new Response.Builder()
+                .request(new Request.Builder().url(target).build())
+                .protocol(Protocol.HTTP_1_1).code(200).message("Some message")
+                .body(ResponseBody.create("someBody", MediaType.parse("application/text")))
+                .build();
+
+        Mockito.doReturn(response).when(httpSvc).get(any());
+
+        /* ACT */
+        final var result = (HttpResponse) service.request(HttpService.Method.GET, target, args);
+
+        /* ASSERT */
+        Mockito.doReturn(response2).when(httpSvc).get(any());
+        final var expected = (HttpResponse) service.get(target, args);
+        assertEquals(expected.getCode(), result.getCode());
+        assertTrue(Arrays.areEqual("someBody".getBytes(StandardCharsets.UTF_8),
+                result.getData().readAllBytes()));
+    }
 }

--- a/src/test/java/io/dataspaceconnector/common/net/HttpServiceTest.java
+++ b/src/test/java/io/dataspaceconnector/common/net/HttpServiceTest.java
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ *  Contributors:
+ *       sovity GmbH
  */
 package io.dataspaceconnector.common.net;
 


### PR DESCRIPTION
The DSC previously allowed users to "override" queries which were defined in the accessUrl of an artifact. This fixes this issue and ignores user queries if they have the same key as the target url.