### PR TITLE
fix: route reference check

### DIFF
--- a/src/main/java/io/dataspaceconnector/common/net/ApiReferenceHelper.java
+++ b/src/main/java/io/dataspaceconnector/common/net/ApiReferenceHelper.java
@@ -31,7 +31,6 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
 import java.net.URL;
-import java.util.UUID;
 
 /**
  * Helper class for managing route references.

--- a/src/main/java/io/dataspaceconnector/common/net/ApiReferenceHelper.java
+++ b/src/main/java/io/dataspaceconnector/common/net/ApiReferenceHelper.java
@@ -19,6 +19,7 @@
  */
 package io.dataspaceconnector.common.net;
 
+import io.dataspaceconnector.common.exception.UUIDFormatException;
 import io.dataspaceconnector.common.util.UUIDUtils;
 import io.dataspaceconnector.config.BasePath;
 import io.dataspaceconnector.model.artifact.Artifact;
@@ -59,8 +60,12 @@ public final class ApiReferenceHelper {
      * @return True, if the URL is a route reference; false otherwise.
      */
     public boolean isRouteReference(final URL url) {
-        final var uuid = UUIDUtils.uuidFromUrl(url);
-        return routeRepository.existsById(uuid);
+        try {
+            final var uuid = UUIDUtils.uuidFromUrl(url);
+            return routeRepository.existsById(uuid);
+        } catch (UUIDFormatException exception) {
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/io/dataspaceconnector/common/net/ApiReferenceHelper.java
+++ b/src/main/java/io/dataspaceconnector/common/net/ApiReferenceHelper.java
@@ -12,24 +12,32 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ *  Contributors:
+ *       sovity GmbH
+ *
  */
 package io.dataspaceconnector.common.net;
 
 import io.dataspaceconnector.config.BasePath;
 import io.dataspaceconnector.model.artifact.Artifact;
+import io.dataspaceconnector.repository.RouteRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
 import java.net.URL;
+import java.util.UUID;
 
 /**
  * Helper class for managing route references.
  */
 @Component
 @RequiredArgsConstructor
+@Log4j2
 public final class ApiReferenceHelper {
 
     /**
@@ -39,16 +47,20 @@ public final class ApiReferenceHelper {
     private String defaultBaseUrl;
 
     /**
-     * Checks whether a URL is a route reference by checking whether the URL starts with the path
-     * to this connector's routes API. The full path to the routes API consists of the application's
-     * base URL and the path segment for the routes API.
+     * Route repository used to check if a given url is a route.
+     */
+    private final RouteRepository routeRepository;
+
+    /**
+     * Checks whether a URL is a route reference by searching for
+     * the uuid of the url in the route repository.
      *
      * @param url The URL to check.
      * @return True, if the URL is a route reference; false otherwise.
      */
     public boolean isRouteReference(final URL url) {
-        final var routesApiUrl = getBaseUrl() + BasePath.ROUTES;
-        return url.toString().startsWith(routesApiUrl);
+        final var id = url.getPath().substring(url.getPath().lastIndexOf('/') + 1);
+        return routeRepository.existsById(UUID.fromString(id));
     }
 
     /**

--- a/src/main/java/io/dataspaceconnector/common/net/ApiReferenceHelper.java
+++ b/src/main/java/io/dataspaceconnector/common/net/ApiReferenceHelper.java
@@ -19,6 +19,7 @@
  */
 package io.dataspaceconnector.common.net;
 
+import io.dataspaceconnector.common.util.UUIDUtils;
 import io.dataspaceconnector.config.BasePath;
 import io.dataspaceconnector.model.artifact.Artifact;
 import io.dataspaceconnector.repository.RouteRepository;
@@ -59,8 +60,8 @@ public final class ApiReferenceHelper {
      * @return True, if the URL is a route reference; false otherwise.
      */
     public boolean isRouteReference(final URL url) {
-        final var id = url.getPath().substring(url.getPath().lastIndexOf('/') + 1);
-        return routeRepository.existsById(UUID.fromString(id));
+        final var uuid = UUIDUtils.uuidFromUrl(url);
+        return routeRepository.existsById(uuid);
     }
 
     /**

--- a/src/main/java/io/dataspaceconnector/common/util/UUIDUtils.java
+++ b/src/main/java/io/dataspaceconnector/common/util/UUIDUtils.java
@@ -23,6 +23,8 @@ import io.dataspaceconnector.common.exception.UUIDCreationException;
 import io.dataspaceconnector.common.exception.UUIDFormatException;
 
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -107,6 +109,23 @@ public final class UUIDUtils {
                     + "problem with the uuid pattern.", exception);
         }
     }
+
+    /**
+     * Extracts a UUID from a URL. If more than one UUID is found the last UUID is returned. See
+     * also {@link #uuidFromUri}.
+     *
+     * @param url The URL from which the UUID should be extracted.
+     * @return the extracted UUID.
+     * @throws UUIDFormatException if the URL does not contain a parsable UUID.
+     */
+    public static UUID uuidFromUrl(final URL url) throws UUIDFormatException {
+        try {
+            return uuidFromUri(url.toURI(), -1);
+        } catch (URISyntaxException exception) {
+            throw new UUIDFormatException("No uuid could be found in the uri.", exception);
+        }
+    }
+
 
     /**
      * Generates a unique UUID, if it does not already exist.

--- a/src/main/java/io/dataspaceconnector/common/util/UUIDUtils.java
+++ b/src/main/java/io/dataspaceconnector/common/util/UUIDUtils.java
@@ -121,7 +121,7 @@ public final class UUIDUtils {
     public static UUID uuidFromUrl(final URL url) throws UUIDFormatException {
         try {
             return uuidFromUri(url.toURI(), -1);
-        } catch (URISyntaxException exception) {
+        } catch (URISyntaxException | IndexOutOfBoundsException exception) {
             throw new UUIDFormatException("No uuid could be found in the uri.", exception);
         }
     }

--- a/src/test/java/io/dataspaceconnector/service/resource/ids/builder/IdsAppRouteBuilderTest.java
+++ b/src/test/java/io/dataspaceconnector/service/resource/ids/builder/IdsAppRouteBuilderTest.java
@@ -35,6 +35,7 @@ import io.dataspaceconnector.model.datasource.DataSource;
 import io.dataspaceconnector.model.endpoint.Endpoint;
 import io.dataspaceconnector.model.endpoint.GenericEndpoint;
 import io.dataspaceconnector.model.route.Route;
+import io.dataspaceconnector.repository.RouteRepository;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,6 +63,9 @@ public class IdsAppRouteBuilderTest {
 
     @MockBean
     private SelfLinkHelper selfLinkHelper;
+
+    @MockBean
+    private RouteRepository routeRepository;
 
     private final URI endpointDocumentation = URI.create("https://documentation.com");
 

--- a/src/test/java/io/dataspaceconnector/service/resource/ids/builder/IdsArtifactBuilderTest.java
+++ b/src/test/java/io/dataspaceconnector/service/resource/ids/builder/IdsArtifactBuilderTest.java
@@ -21,6 +21,8 @@ import io.dataspaceconnector.model.artifact.Artifact;
 import io.dataspaceconnector.model.artifact.ArtifactDesc;
 import io.dataspaceconnector.model.artifact.ArtifactFactory;
 import io.dataspaceconnector.model.base.Entity;
+import io.dataspaceconnector.repository.DapsRepository;
+import io.dataspaceconnector.repository.RouteRepository;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,6 +55,9 @@ public class IdsArtifactBuilderTest {
 
     @MockBean
     private SelfLinkHelper selfLinkHelper;
+
+    @MockBean
+    private RouteRepository routeRepository;
 
     private final ZonedDateTime date = ZonedDateTime.now(ZoneOffset.UTC);
 

--- a/src/test/java/io/dataspaceconnector/service/resource/ids/builder/IdsArtifactBuilderTest.java
+++ b/src/test/java/io/dataspaceconnector/service/resource/ids/builder/IdsArtifactBuilderTest.java
@@ -56,8 +56,6 @@ public class IdsArtifactBuilderTest {
     @MockBean
     private SelfLinkHelper selfLinkHelper;
 
-    @MockBean
-    private RouteRepository routeRepository;
 
     private final ZonedDateTime date = ZonedDateTime.now(ZoneOffset.UTC);
 


### PR DESCRIPTION
The route reference check was previously relying on the base url. Since the base url can change (e.g. when hosting locally in docker) the new check searches for the uuid in the route repository.

This very likely fixes https://github.com/International-Data-Spaces-Association/DataspaceConnector/issues/355. 