### PR TITLE
updated IAIS repository URL (http:// -> https://)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -667,7 +667,7 @@
 				<enabled>false</enabled>
 			</snapshots>
 			<id>eis-public-repo</id>
-			<url>http://maven.iais.fraunhofer.de/artifactory/eis-ids-public</url>
+			<url>https://maven.iais.fraunhofer.de/artifactory/eis-ids-public</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
http://maven.iais.fraunhofer.de/ui/native/eis-ids-public isn't accessible anymore, but
https://maven.iais.fraunhofer.de/ui/native/eis-ids-public is accessible

addresses #678