### PR TITLE
Stick to maven version 3.6 to avoid problems with dependencies defining additional http repositories:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # Build application
-FROM maven:3-eclipse-temurin-17 AS builder
+FROM maven:3.6-openjdk-17 AS builder
 WORKDIR /app
 COPY pom.xml .
 ## Dependencies


### PR DESCRIPTION
addresses
https://github.com/International-Data-Spaces-Association/DataspaceConnector/issues/678

See also the discussion here: https://github.com/International-Data-Spaces-Association/DataspaceConnector/pull/679

I don't know if there are side effects by using OpenJDK instead of eclipse-temurin. I guess there shouldn't.